### PR TITLE
custom rsync options

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,10 @@ const CONFIG = require('./config.json');
             .source(CONFIG[project].from)
             .destination(CONFIG[project].to);
 
+        for (let option_key in (CONFIG[project].options || {})) {
+            rsync.set(option_key, CONFIG[project].options[option_key])
+        }
+
         consoleTimestamp.log(`[sync start] ${project}`);
         return new Promise((resolve, reject) => {
             const rsyncProcess = rsync.execute((error, code, command) => {


### PR DESCRIPTION
I wanted to set my custom options. So, I developed this mechanism.

I am also a bit concerned by the default options.

We want sensible defaults and we don't want to be headache for first-timers. But, we also don't want to enforce anyone to use those options. @Splurov Any solution you have in mind?
Maybe, we have have a new `default-options: false`(true by default) which does not enforce anyone to use the default options? By that way, this tool becomes easy enough to start for first-timers plus extendible/customizable enough for someone who wants to customize in his own way.