### PR TITLE
watch ignore excluded files and folders

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,8 @@ const CONFIG = require('./config.json');
     function watch(project) {
         const watcher = chokidar.watch(CONFIG[project].from, {
             ignoreInitial: true,
+            ignored: CONFIG[project].exclude,
+            cwd: CONFIG[project].from,
         });
         watchers.push({project, watcher});
 


### PR DESCRIPTION
This is a bit of a performance improvement.
In node 10, it can take up to 75% CPU while watching on my Mac. I am not sure if this is a problem with chokidar or in Node version 10 itself. It works fine on node version 9.

I will try to upgrade chokidar to see if it fixes the issue.

In any case, this should help a little bit in performance. The CPU consumption was reduced from 75% to 20%.