### PR TITLE
Example for no-owner and similar no-perms

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -16,6 +16,7 @@ module.exports = {
       "times": null,
       "delete": null,
       "delete-during": null,
+      "no-owner": null,
     },
   },
 };


### PR DESCRIPTION
I had to look into the workings of the node_module: `rsync` to know the usage of `no-perms` and `no-group`.

Hope this would make it easier to find.